### PR TITLE
fix: add QSpectre flag

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,20 @@
       "target_name": "foreground_love",
       "sources": [
         "src/foreground-love.cc"
-      ]
+      ],
+      'msvs_settings': {
+        'VCCLCompilerTool': {
+          'AdditionalOptions': [
+            '/Qspectre',
+            '/guard:cf'
+          ]
+        },
+        'VCLinkerTool': {
+          'AdditionalOptions': [
+            '/guard:cf'
+          ]
+        }
+      }
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "windows-foreground-love",
   "version": "0.4.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "windows-foreground-love",
+      "version": "0.4.0",
+      "license": "MIT"
+    }
+  }
 }


### PR DESCRIPTION
This PR adds the /Qspectre and /guard:cf flags to the project.

More info on the flags:

https://learn.microsoft.com/en-us/cpp/build/reference/qspectre?view=msvc-170

https://learn.microsoft.com/en-us/cpp/build/reference/guard-enable-control-flow-guard?view=msvc-170