### PR TITLE
fix: bump lockfile version and add flags for binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,20 @@
       "target_name": "foreground_love",
       "sources": [
         "src/foreground-love.cc"
-      ]
+      ],
+      'msvs_settings': {
+        'VCCLCompilerTool': {
+          'AdditionalOptions': [
+            '/Qspectre',
+            '/guard:cf'
+          ]
+        },
+        'VCLinkerTool': {
+          'AdditionalOptions': [
+            '/guard:cf'
+          ]
+        }
+      }
     }
   ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,11 +5,16 @@
       "sources": [
         "src/foreground-love.cc"
       ],
+      'msvs_configuration_attributes': {
+        'SpectreMitigation': 'Spectre'
+      },
       'msvs_settings': {
         'VCCLCompilerTool': {
           'AdditionalOptions': [
-            '/Qspectre',
-            '/guard:cf'
+            '/guard:cf',
+            '/we4244',
+            '/we4267',
+            '/ZH:SHA_256'
           ]
         },
         'VCLinkerTool': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "windows-foreground-love",
   "version": "0.4.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "windows-foreground-love",
+      "version": "0.4.0",
+      "license": "MIT"
+    }
+  }
 }


### PR DESCRIPTION
Hi @the-ress, we (the VS Code team) are currently using windows-foreground-love in VS Code.

This PR adds some flags to binding.gyp so that the package can be compliant with [microsoft/binskim](https://github.com/microsoft/binskim) security policies.

Let me know if you have any questions or concerns. Thanks!